### PR TITLE
Fix E2 ITEM_UNIT_PRICE description and improve Sales Channel documentation

### DIFF
--- a/content/payments/e2-interface/authcode.md
+++ b/content/payments/e2-interface/authcode.md
@@ -1,10 +1,17 @@
 ---
-title: "Calculating the Payment AUTHCODE"
+title: Calculating the AUTHCODE for E2 Payment
 draft: false
 weight: 3
 ---
 
-`AUTHCODE` is calculated by joining all fields listed in `PARAMS_IN`. Fields are joined by placing the `|` character (pipe, vertical bar) between each two fields. `AUTHCODE` is formed from this string by calculating a sum using algorithm from `ALG` field. This sum is converted to its 64 character hexadecimal form and lowercase letters are capitalized.
+The `AUTHCODE` for the E2 payment is calculated as follows:
+
+1. Join all fields listed in `PARAMS_IN` by placing the `|` character (pipe, vertical bar) between each two fields.
+2. Calculate a sum using the algorithm from the `ALG` field.
+3. Convert this hash to its 64-character hexadecimal form.
+4. Transform all the letters to uppercase.
+
+{{% notice note %}}In this example character set UTF-8 is used. Paytrail supports character sets UTF-8 and ISO-8859-1. Calculation for AUTHCODE has to be done using same character set that is used when sending the form to Paytrail. Paytrail’s service will detect the used character set and use the same character set when calculating the AUTHCODE.{{% /notice %}}
 
 ### Using All the Fields
 
@@ -36,153 +43,112 @@ This example covers sending payment information in the most complete form. This 
     <input name="URL_NOTIFY" type="hidden" value="http://www.example.com/notify">
     <input name="LOCALE" type="hidden" value="en_US">
     <input name="CURRENCY" type="hidden" value="EUR">
-    <input name="REFERENCE_NUMBER" type="hidden" value="">
-    <input name="PAYMENT_METHODS" type="hidden" value="">
+    <input name="REFERENCE_NUMBER" type="hidden" value="REF-0001">
+    <input name="PAYMENT_METHODS" type="hidden" value="1">
     <input name="PAYER_PERSON_PHONE" type="hidden" value="01234567890">
     <input name="PAYER_PERSON_EMAIL" type="hidden" value="john.doe@example.com">
     <input name="PAYER_PERSON_FIRSTNAME" type="hidden" value="John">
     <input name="PAYER_PERSON_LASTNAME" type="hidden" value="Doe">
-    <input name="PAYER_COMPANY_NAME" type="hidden" value="Test company">
-    <input name="PAYER_PERSON_ADDR_STREET" type="hidden" value="Test street 1">
+    <input name="PAYER_COMPANY_NAME" type="hidden" value="Test Company">
+    <input name="PAYER_PERSON_ADDR_STREET" type="hidden" value="Test Street 1">
     <input name="PAYER_PERSON_ADDR_POSTAL_CODE" type="hidden" value="608009">
-    <input name="PAYER_PERSON_ADDR_TOWN" type="hidden" value="Test town">
+    <input name="PAYER_PERSON_ADDR_TOWN" type="hidden" value="Test Town">
     <input name="PAYER_PERSON_ADDR_COUNTRY" type="hidden" value="AA">
     <input name="VAT_IS_INCLUDED" type="hidden" value="1">
     <input name="ALG" type="hidden" value="1">
-    <input name="AUTHCODE" type="hidden" value="EAC78AB322614BB98F43FFF2EF55E71075DDC79634EA728C9C842EFF8E0AC0C9">
+    <input name="AUTHCODE" type="hidden" value="661A6766D2FCC6768232D54A0DC634D812619D32F71DFA56F8A3B61FDFD77262">
   <input type="submit" value="Pay here">
 </form>
 ```
 
-#### `MERCHANT AUTHENTICATION HASH`
-`6pKF4jkv97zmqBJ3ZL8gUw5DfT2NMQ`
+* **Merchant Authentication Hash**: `6pKF4jkv97zmqBJ3ZL8gUw5DfT2NMQ`
 
-#### `MERCHANT_ID`
-`13466`
+* **MERCHANT_ID**: `13466`
 
-#### `URL_SUCCESS`
-<http://www.example.com/success>
+* **URL_SUCCESS**: <http://www.example.com/success>
 
-#### `URL_CANCEL`
-<http://www.example.com/cancel>
+* **URL_CANCEL**: <http://www.example.com/cancel>
 
-#### `ORDER_NUMBER`
-`123456`
+* **ORDER_NUMBER**: `123456`
 
-#### `PARAMS_IN`
-`MERCHANT_ID,URL_SUCCESS,URL_CANCEL,ORDER_NUMBER,PARAMS_IN,PARAMS_OUT,ITEM_TITLE[0],ITEM_ID[0],ITEM_QUANTITY[0],ITEM_UNIT_PRICE[0],ITEM_VAT_PERCENT[0],ITEM_DISCOUNT_PERCENT[0],ITEM_TYPE[0],ITEM_TITLE[1],ITEM_ID[1],ITEM_QUANTITY[1],ITEM_UNIT_PRICE[1],ITEM_VAT_PERCENT[1],ITEM_DISCOUNT_PERCENT[1],ITEM_TYPE[1],MSG_UI_MERCHANT_PANEL,URL_NOTIFY,LOCALE,CURRENCY,REFERENCE_NUMBER,PAYMENT_METHODS,PAYER_PERSON_PHONE,PAYER_PERSON_EMAIL,PAYER_PERSON_FIRSTNAME,PAYER_PERSON_LASTNAME,PAYER_COMPANY_NAME,PAYER_PERSON_ADDR_STREET,PAYER_PERSON_ADDR_POSTAL_CODE,PAYER_PERSON_ADDR_TOWN,PAYER_PERSON_ADDR_COUNTRY,VAT_IS_INCLUDED,ALG`
+* **PARAMS_IN**: `MERCHANT_ID,URL_SUCCESS,URL_CANCEL,ORDER_NUMBER,PARAMS_IN,PARAMS_OUT,ITEM_TITLE[0],ITEM_ID[0],ITEM_QUANTITY[0],ITEM_UNIT_PRICE[0],ITEM_VAT_PERCENT[0],ITEM_DISCOUNT_PERCENT[0],ITEM_TYPE[0],ITEM_TITLE[1],ITEM_ID[1],ITEM_QUANTITY[1],ITEM_UNIT_PRICE[1],ITEM_VAT_PERCENT[1],ITEM_DISCOUNT_PERCENT[1],ITEM_TYPE[1],MSG_UI_MERCHANT_PANEL,URL_NOTIFY,LOCALE,CURRENCY,REFERENCE_NUMBER,PAYMENT_METHODS,PAYER_PERSON_PHONE,PAYER_PERSON_EMAIL,PAYER_PERSON_FIRSTNAME,PAYER_PERSON_LASTNAME,PAYER_COMPANY_NAME,PAYER_PERSON_ADDR_STREET,PAYER_PERSON_ADDR_POSTAL_CODE,PAYER_PERSON_ADDR_TOWN,PAYER_PERSON_ADDR_COUNTRY,VAT_IS_INCLUDED,ALG`
 
-#### `PARAMS_OUT`
-`ORDER_NUMBER,PAYMENT_ID,AMOUNT,CURRENCY,PAYMENT_METHOD,TIMESTAMP,STATUS`
+* **PARAMS_OUT**: `ORDER_NUMBER,PAYMENT_ID,AMOUNT,CURRENCY,PAYMENT_METHOD,TIMESTAMP,STATUS`
 
-#### `ITEM_TITLE`
-Product 101
+* **ITEM_TITLE**: `Product 101`
 
-#### `ITEM_ID`
-Product 101
+* **ITEM_ID**: `101`
 
-#### `ITEM_QUANTITY`
-`2`
+* **ITEM_QUANTITY**: `2`
 
-#### `ITEM_UNIT_PRICE`
-`300.00`
+* **ITEM_UNIT_PRICE**: `300.00`
 
-#### `ITEM_VAT_PERCENT`
-`15.00`
+* **ITEM_VAT_PERCENT**: `15.00`
 
-#### `ITEM_DISCOUNT_PERCENT`
-`50`
+* **ITEM_DISCOUNT_PERCENT**: `50`
 
-#### `ITEM_TYPE`
-`1`
+* **ITEM_TYPE**: `1`
 
-#### `ITEM_TITLE`
-Product 101
+* **ITEM_TITLE**: `Product 202`
 
-#### `ITEM_ID`
-`202`
+* **ITEM_ID**: `202`
 
-#### `ITEM_QUANTITY`
-`4`
+* **ITEM_QUANTITY**: `4`
 
-#### `ITEM_UNIT_PRICE`
-12.50
+* **ITEM_UNIT_PRICE**: `12.50`
 
-#### `ITEM_VAT_PERCENT`
-`0`
+* **ITEM_VAT_PERCENT**: `0`
 
-#### `ITEM_DISCOUNT_PERCENT`
-`0`
+* **ITEM_DISCOUNT_PERCENT**: `0`
 
-#### `ITEM_TYPE`
-`1`
+* **ITEM_TYPE**: `1`
 
-#### `MSG_UI_MERCHANT_PANEL`
-Order 123456
+* **MSG_UI_MERCHANT_PANEL**: `Order 123456`
 
-#### `URL_NOTIFY`
-<http://www.example.com/notify>
+* **URL_NOTIFY**: <http://www.example.com/notify>
 
-#### `LOCALE`
-`en_US`
+* **LOCALE**: `en_US`
 
-#### `CURRENCY`
-`EUR`
+* **CURRENCY**: `EUR`
 
-#### `REFERENCE_NUMBER`
-`REF-0001`
+* **REFERENCE_NUMBER**: `REF-0001`
 
-#### `PAYMENT_METHODS`
-`1`
+* **PAYMENT_METHODS**: `1`
 
-#### `PAYER_PERSON_PHONE`
-`01234567890`
+* **PAYER_PERSON_PHONE**: `01234567890`
 
-#### `PAYER_PERSON_EMAIL`
-`john.doe@example.com`
+* **PAYER_PERSON_EMAIL**: `john.doe@example.com`
 
-#### `PAYER_PERSON_FIRSTNAME`
-John
+* **PAYER_PERSON_FIRSTNAME**: `John`
 
-#### `PAYER_PERSON_LASTNAME`
-Doe
+* **PAYER_PERSON_LASTNAME**: `Doe`
 
-#### `PAYER_COMPANY_NAME`
-Test company
+* **PAYER_COMPANY_NAME**: `Test Company`
 
-#### `PAYER_PERSON_ADDR_STREET`
-Test street 1
+* **PAYER_PERSON_ADDR_STREET**: `Test Street 1`
 
-#### `PAYER_PERSON_ADDR_POSTAL_CODE`
-608009
+* **PAYER_PERSON_ADDR_POSTAL_CODE**: `608009`
 
-#### `PAYER_PERSON_ADDR_TOWN`
-Test town
+* **PAYER_PERSON_ADDR_TOWN**: `Test Town`
 
-#### `PAYER_PERSON_ADDR_COUNTRY`
-`AA`
+* **PAYER_PERSON_ADDR_COUNTRY**: `AA`
 
-#### `VAT_IS_INCLUDED`
-`1`
+* **VAT_IS_INCLUDED**: `1`
 
-#### `ALG`
-`1`
-
-#### `AUTHCODE`
-`EAC78AB322614BB98F43FFF2EF55E71075DDC79634EA728C9C842EFF8E0AC0C9`
+* **ALG**: `1`
 
 ### Calculation Formula
 
 Now the string to be used for `AUTHCODE` calculation is formed by joining the fields above:
 
 ```plain
-6pKF4jkv97zmqBJ3ZL8gUw5DfT2NMQ|13466|http://www.example.com/success|http://www.example.com/cancel|123456|MERCHANT_ID,URL_SUCCESS,URL_CANCEL,ORDER_NUMBER,PARAMS_IN,PARAMS_OUT,ITEM_TITLE[0],ITEM_ID[0],ITEM_QUANTITY[0],ITEM_UNIT_PRICE[0],ITEM_VAT_PERCENT[0],ITEM_DISCOUNT_PERCENT[0],ITEM_TYPE[0],ITEM_TITLE[1],ITEM_ID[1],ITEM_QUANTITY[1],ITEM_UNIT_PRICE[1],ITEM_VAT_PERCENT[1],ITEM_DISCOUNT_PERCENT[1],ITEM_TYPE[1],MSG_UI_MERCHANT_PANEL,URL_NOTIFY,LOCALE,CURRENCY,REFERENCE_NUMBER,PAYMENT_METHODS,PAYER_PERSON_PHONE,PAYER_PERSON_EMAIL,PAYER_PERSON_FIRSTNAME,PAYER_PERSON_LASTNAME,PAYER_COMPANY_NAME,PAYER_PERSON_ADDR_STREET,PAYER_PERSON_ADDR_POSTAL_CODE,PAYER_PERSON_ADDR_TOWN,PAYER_PERSON_ADDR_COUNTRY,VAT_IS_INCLUDED,ALG|ORDER_NUMBER,PAYMENT_ID,AMOUNT,CURRENCY,PAYMENT_METHOD,TIMESTAMP,STATUS|Product 101|101|2|300.00|15.00|50|1|Product 202|202|4|12.50|0|0|1|Order 123456|http://www.example.com/notify|en_US|EUR|||01234567890|john.doe@example.com|John|Doe|Test company|Test street 1|608009|Test town|AA|1|1
+6pKF4jkv97zmqBJ3ZL8gUw5DfT2NMQ|13466|http://www.example.com/success|http://www.example.com/cancel|123456|MERCHANT_ID,URL_SUCCESS,URL_CANCEL,ORDER_NUMBER,PARAMS_IN,PARAMS_OUT,ITEM_TITLE[0],ITEM_ID[0],ITEM_QUANTITY[0],ITEM_UNIT_PRICE[0],ITEM_VAT_PERCENT[0],ITEM_DISCOUNT_PERCENT[0],ITEM_TYPE[0],ITEM_TITLE[1],ITEM_ID[1],ITEM_QUANTITY[1],ITEM_UNIT_PRICE[1],ITEM_VAT_PERCENT[1],ITEM_DISCOUNT_PERCENT[1],ITEM_TYPE[1],MSG_UI_MERCHANT_PANEL,URL_NOTIFY,LOCALE,CURRENCY,REFERENCE_NUMBER,PAYMENT_METHODS,PAYER_PERSON_PHONE,PAYER_PERSON_EMAIL,PAYER_PERSON_FIRSTNAME,PAYER_PERSON_LASTNAME,PAYER_COMPANY_NAME,PAYER_PERSON_ADDR_STREET,PAYER_PERSON_ADDR_POSTAL_CODE,PAYER_PERSON_ADDR_TOWN,PAYER_PERSON_ADDR_COUNTRY,VAT_IS_INCLUDED,ALG|ORDER_NUMBER,PAYMENT_ID,AMOUNT,CURRENCY,PAYMENT_METHOD,TIMESTAMP,STATUS|Product 101|101|2|300.00|15.00|50|1|Product 202|202|4|12.50|0|0|1|Order 123456|http://www.example.com/notify|en_US|EUR|REF-0001|1|01234567890|john.doe@example.com|John|Doe|Test Company|Test Street 1|608009|Test Town|AA|1|1
 ```
 
 **SHA-256** sum is counted from this string (note uppercase):
 
 ```plain
-EAC78AB322614BB98F43FFF2EF55E71075DDC79634EA728C9C842EFF8E0AC0C9
+661A6766D2FCC6768232D54A0DC634D812619D32F71DFA56F8A3B61FDFD77262
 ```
 
 ### Using Only the Required Fields
@@ -201,40 +167,29 @@ EAC78AB322614BB98F43FFF2EF55E71075DDC79634EA728C9C842EFF8E0AC0C9
 </form>
 ```
 
-#### `MERCHANT AUTHENTICATION HASH`
-`6pKF4jkv97zmqBJ3ZL8gUw5DfT2NMQ`
+* **MERCHANT AUTHENTICATION HASH**: `6pKF4jkv97zmqBJ3ZL8gUw5DfT2NMQ`
 
-#### `MERCHANT_ID`
-`13466`
+* **MERCHANT_ID**: `13466`
 
-#### `URL_SUCCESS`
-<http://www.example.com/success>
+* **URL_SUCCESS**: <http://www.example.com/success>
 
-#### `URL_CANCEL`
-<http://www.example.com/cancel>
+* **URL_CANCEL**: <http://www.example.com/cancel>
 
-#### `ORDER_NUMBER`
-`123456`
+* **ORDER_NUMBER**: `123456`
 
-#### `PARAMS_IN`
-`MERCHANT_ID,URL_SUCCESS,URL_CANCEL,ORDER_NUMBER,PARAMS_IN,PARAMS_OUT,AMOUNT`
+* **PARAMS_IN**: `MERCHANT_ID,URL_SUCCESS,URL_CANCEL,ORDER_NUMBER,PARAMS_IN,PARAMS_OUT,AMOUNT`
 
-#### `PARAMS_OUT`
-`PAYMENT_ID,TIMESTAMP,STATUS`
+* **PARAMS_OUT**: `PAYMENT_ID,TIMESTAMP,STATUS`
 
-#### `AMOUNT`
-`350.00`
+* **AMOUNT**: `350.00`
 
-#### `AUTHCODE`
-`BBDF8997A56F97DC0A46C99C88C2EEF9D541AAD59CFF2695D0DD9AF474086D71`
-
-Now the string to be used for `AUTHCODE` calculation is formed by joining the fields above:
+The string used to calculate `AUTHCODE` is created by combining fields above.
 
 ```plain
 6pKF4jkv97zmqBJ3ZL8gUw5DfT2NMQ|13466|http://www.example.com/success|http://www.example.com/cancel|123456|MERCHANT_ID,URL_SUCCESS,URL_CANCEL,ORDER_NUMBER,PARAMS_IN,PARAMS_OUT,AMOUNT|PAYMENT_ID,TIMESTAMP,STATUS|350.00
 ```
 
-**SHA-256** sum is counted from this string (note uppercase): 
+**SHA-256** sum is computed from this string (note uppercase):
 
 ```plain
 BBDF8997A56F97DC0A46C99C88C2EEF9D541AAD59CFF2695D0DD9AF474086D71

--- a/content/payments/e2-interface/fields.md
+++ b/content/payments/e2-interface/fields.md
@@ -130,7 +130,9 @@ Product ID.
 Quantity of products. If a decimal number such as `0.5` is used, the Collector payment method will be hidden. Default is `1`.
 
 #### `ITEM_UNIT_PRICE[N]`
-The price for a single product. Required if product rows are included in data. If `VAT_IS_INCLUDED = 0`, this is price not including VAT. Price may be negative value if discount is given.
+The price for a single product with **up to two decimals**. Required if product rows are included in data.
+
+If `VAT_IS_INCLUDED = 0`, this is price not including VAT. Price may be negative value if discount is given.
 
 #### `ITEM_VAT_PERCENT[N]`
 VAT percent used for product. Required if product rows are included in data.

--- a/content/sales-channels/authcode.md
+++ b/content/sales-channels/authcode.md
@@ -1,5 +1,5 @@
 ---
-title: Calculating the AUTHCODE
+title: Calculating the AUTHCODE for Sales Channel Payment
 draft: false
 weight: 3
 ---
@@ -7,60 +7,54 @@ weight: 3
 The `AUTHCODE` for the channel payment is calculated as follows:
 
 1. Combine all the fields in the same order they appear at the form.
-2. Insert pipe character (`|`) between the fields. If some field is not sent, insert a blank string (`''`) in its place. This will result in two or more pipe characters next to each other. The first field of the string has to be the channel secret. `AUTHCODE` will be created from this string with MD5 function. The value will be a 32 byte hexadecimal string.
-3. Replace lower case letters with upper case letters.
+2. Insert pipe character (`|`) between the fields. If some field is not sent, insert a blank string (`''`) in its place. This will result in two or more pipe characters next to each other. The first field of the string has to be the channel secret
+3. Calculate the **MD5** hash from this value. The value will be a 32-byte hexadecimal string.
+4. Transform all the letters to uppercase.
 
 {{% notice note %}}In this example character set UTF-8 is used. Paytrail supports character sets UTF-8 and ISO-8859-1. Calculation for AUTHCODE has to be done using same character set that is used when sending the form to Paytrail. Paytrail’s service will detect the used character set and use the same character set when calculating the AUTHCODE.{{% /notice %}}
 
-In the example above the values of fields are as described below.
+Assume we have the following values for `AUTHCODE` calculation:
 
-* **Channel secret:** `12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678`
-* **Channel ID**: `123`
-* **Order number:** `12345678`
-* **Currency:** `EUR`
-* **Return address (Successful payment):** <https://www.example.com/ok>
-* **Return address (Cancelled payment):** <https://www.example.com/cancel>
-* **Notify address:** <https://www.example.com/notify>
-* **Interface version:** `1`
-* **Culture code:** `fi_FI`
-* **Preselected method for the payment page bypass:** `1`
-* **Contact's telephone number:** `+01234567890`
-* **Contact's cellphone number:** `+35812345678`
-* **Contact's email address:** `example@example.com`
-* **Contact's first name:** _Jane_
-* **Contact's last name:** _Doe_
-* **Contact's company:** _Test Ltd_
-* **Contact's street address:** _Test Street 1_
-* **Contact's zip code:** _43210_
-* **Contact's city:** _Helsinki_
-* **Contact's country:** FI
-* **VAT included:** `1`
-* **Amount of items:** `2`
-* **Product #1**
-  * **Name:** _Example product 1_
-  * **Number:** `12345`
-  * **Amount:** `1`
-  * **Price:** `10.00`
-  * **Tax percent:** `22.00`
-  * **Merchant ID:** `13466`
-  * **Channel commission class ID:** `1`
-  * **Discount:** `0`
-  * **Type:** `1`
-* **Product #2**
-  * **Name:** _Example product 2_
-  * **Number:** `12345`
-  * **Amount:** `2`
-  * **Price:** `5.00`
-  * **Tax percent:** `22.00`
-  * **Merchant ID:** `13466`
-  * **Channel commission class ID:** `1`
-  * **Discount:** `20.00`
-  * **Type:** `1`
+* **CHANNEL_SECRET:** `12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678`
+* **CHANNEL_ID**: `123`
+* **ORDER_NUMBER:** `12345678`
+* **CURRENCY:** `EUR`
+* **RETURN_ADDRESS:** <https://www.example.com/ok>
+* **CANCEL_ADDRESS:** <https://www.example.com/cancel>
+* **NOTIFY_ADDRESS:** <https://www.example.com/notify>
+* **VERSION:** `1`
+* **CULTURE:** `fi_FI`
+* **PRESELECTED_METHOD:** `1`
+* **CONTACT_TELNO:** `+01234567890`
+* **CONTACT_CELLNO:** `+35812345678`
+* **CONTACT_EMAIL:** `example@example.com`
+* **CONTACT_FIRSTNAME:** `Jane`
+* **CONTACT_LASTNAME:** `Doe`
+* **CONTACT_COMPANY:** `Test Ltd`
+* **CONTACT_ADDR_STREET:** `Test Street 1`
+* **CONTACT_ADDR_ZIP:** `43210`
+* **CONTACT_ADDR_CITY:** `Helsinki`
+* **CONTACT_ADDR_COUNTRY:** `FI`
+* **INCLUDE_VAT:** `1`
+* **ITEMS:** `1`
+* **ITEM_TITLE[0]:** `Example product 1`
+* **ITEM_NO[0]:** `12345`
+* **ITEM_AMOUNT[0]:** `1`
+* **ITEM_PRICE[0]:** `10.00`
+* **ITEM_TAX[0]:** `22.00`
+* **ITEM_MERCHANT_ID[0]:** `13466`
+* **ITEM_CP[0]:** `1`
+* **ITEM_DISCOUNT[0]:** `0`
+* **ITEM_TYPE[0]:** `1`
 
 The string used to calculate `AUTHCODE` is created by combining fields above.
 
 ```plain
-12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678|123|12345678|EUR|https://www.example.com/ok|https://www.example.com/cancel|https://www.example.com/notify|1|fi_FI|||+35812345678||example@example.com|Jane|Doe|Test Ltd|Teststreet 1|43210|Helsinki|FI|1|2|Example product 1|12345|1|10.00|22.00|13466|1|0|1|Example product 2|12346|2|5.00|22.00|13466|1|20.00|1
+12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678|123|12345678|EUR|https://www.example.com/ok|https://www.example.com/cancel|https://www.example.com/notify|1|fi_FI|1|+01234567890|+35812345678|example@example.com|Jane|Doe|Test Ltd|Test Street 1|43210|Helsinki|FI|1|1|Example product 1|12345|1|10.00|22.00|13466|1|0|1
 ```
 
-MD5 hash value in upper case is `4FA11FF0D41C30B6F3A8AAEB814FD325`.
+**MD5** hash is computed from this string (note uppercase):
+
+```plain
+64F47F0DA8D38955E0DB8CC5A9D154AA
+```

--- a/content/sales-channels/authcode.md
+++ b/content/sales-channels/authcode.md
@@ -1,0 +1,66 @@
+---
+title: Calculating the AUTHCODE
+draft: false
+weight: 3
+---
+
+The `AUTHCODE` for the channel payment is calculated as follows:
+
+1. Combine all the fields in the same order they appear at the form.
+2. Insert pipe character (`|`) between the fields. If some field is not sent, insert a blank string (`''`) in its place. This will result in two or more pipe characters next to each other. The first field of the string has to be the channel secret. `AUTHCODE` will be created from this string with MD5 function. The value will be a 32 byte hexadecimal string.
+3. Replace lower case letters with upper case letters.
+
+{{% notice note %}}In this example character set UTF-8 is used. Paytrail supports character sets UTF-8 and ISO-8859-1. Calculation for AUTHCODE has to be done using same character set that is used when sending the form to Paytrail. Paytrail’s service will detect the used character set and use the same character set when calculating the AUTHCODE.{{% /notice %}}
+
+In the example above the values of fields are as described below.
+
+* **Channel secret:** `12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678`
+* **Channel ID**: `123`
+* **Order number:** `12345678`
+* **Currency:** `EUR`
+* **Return address (Successful payment):** <https://www.example.com/ok>
+* **Return address (Cancelled payment):** <https://www.example.com/cancel>
+* **Notify address:** <https://www.example.com/notify>
+* **Interface version:** `1`
+* **Culture code:** `fi_FI`
+* **Preselected method for the payment page bypass:** `1`
+* **Contact's telephone number:** `+01234567890`
+* **Contact's cellphone number:** `+35812345678`
+* **Contact's email address:** `example@example.com`
+* **Contact's first name:** _Jane_
+* **Contact's last name:** _Doe_
+* **Contact's company:** _Test Ltd_
+* **Contact's street address:** _Test Street 1_
+* **Contact's zip code:** _43210_
+* **Contact's city:** _Helsinki_
+* **Contact's country:** FI
+* **VAT included:** `1`
+* **Amount of items:** `2`
+* **Product #1**
+  * **Name:** _Example product 1_
+  * **Number:** `12345`
+  * **Amount:** `1`
+  * **Price:** `10.00`
+  * **Tax percent:** `22.00`
+  * **Merchant ID:** `13466`
+  * **Channel commission class ID:** `1`
+  * **Discount:** `0`
+  * **Type:** `1`
+* **Product #2**
+  * **Name:** _Example product 2_
+  * **Number:** `12345`
+  * **Amount:** `2`
+  * **Price:** `5.00`
+  * **Tax percent:** `22.00`
+  * **Merchant ID:** `13466`
+  * **Channel commission class ID:** `1`
+  * **Discount:** `20.00`
+  * **Type:** `1`
+
+The string used to calculate `AUTHCODE` is created by combining fields above.
+
+```plain
+12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678|123|12345678|EUR|https://www.example.com/ok|https://www.example.com/cancel|https://www.example.com/notify|1|fi_FI|||+35812345678||example@example.com|Jane|Doe|Test Ltd|Teststreet 1|43210|Helsinki|FI|1|2|Example product 1|12345|1|10.00|22.00|13466|1|0|1|Example product 2|12346|2|5.00|22.00|13466|1|20.00|1
+```
+
+MD5 hash value in upper case is `4FA11FF0D41C30B6F3A8AAEB814FD325`.

--- a/content/sales-channels/testing.md
+++ b/content/sales-channels/testing.md
@@ -13,6 +13,8 @@ The sales channel can be tested with the ID and channel secret shown below.
 
 Below is an example of a form submit that sends payment order to Paytrail’s payment service.
 
+See [**here**][authcode] on calculating the `AUTHCODE`.
+
 ```html
 <form action="https://payment.paytrail.com/channel-payment" method="post">
     <input name="CHANNEL_ID" value="123">
@@ -22,35 +24,32 @@ Below is an example of a form submit that sends payment order to Paytrail’s pa
     <input name="CANCEL_ADDRESS" value="https://www.example.com/cancel">
     <input name="NOTIFY_ADDRESS" value="https://www.example.com/notify">
     <input name="VERSION" value="1">
-    <!-- CULTURE is optional -->
-    <!-- PRESELECTED_METHOD is optional -->
-
-    <!-- CONTACT_TELNO is optional -->
-    <!-- CONTACT_CELLNO is optional -->
+    <input name="CULTURE" value="fi_FI">
+    <input name="PRESELECTED_METHOD" value="1">
+    <input name="CONTACT_TELNO" value="+01234567890">
+    <input name="CONTACT_CELLNO" value="+35812345678">
     <input name="CONTACT_EMAIL" value="example@example.com">
     <input name="CONTACT_FIRSTNAME" value="Jane">
     <input name="CONTACT_LASTNAME" value="Doe">
-
-    <!-- CONTACT_COMPANY is optional -->
-    <input name="CONTACT_ADDR_STREET" value="Teststreet 1">
+    <input name="CONTACT_COMPANY" value="Test Ltd">
+    <input name="CONTACT_ADDR_STREET" value="Test Street 1">
     <input name="CONTACT_ADDR_ZIP" value="43210">
     <input name="CONTACT_ADDR_CITY" value="Helsinki">
     <input name="CONTACT_ADDR_COUNTRY" value="FI">
     <input name="INCLUDE_VAT" value="1" />
     <input name="ITEMS" value="1">
-
     <input name="ITEM_TITLE[0]" value="Example product 1">
-
-    <!-- ITEM_NO is optional -->
+    <input name="ITEM_NO[0]" value="12345">
     <input name="ITEM_AMOUNT[0]" value="1">
     <input name="ITEM_PRICE[0]" value="10.00">
     <input name="ITEM_TAX[0]" value="22.00">
     <input name="ITEM_MERCHANT_ID[0]" value="13466">
     <input name="ITEM_CP[0]" value="1">
-
-    <!-- ITEM_DISCOUNT is optional -->
-    <!-- ITEM_TYPE is optional -->
-    <input name="AUTHCODE" value="D40ABA779948475B9F8E59EAB0EB7A9B">
+    <input name="ITEM_DISCOUNT[0]" value="0">
+    <input name="ITEM_TYPE[0]" value="1">
+    <input name="AUTHCODE" value="64F47F0DA8D38955E0DB8CC5A9D154AA">
     <input type="image" src="https://ssl.paytrail.com/logo/payhere_fin.jpg">
 </form>
 ```
+
+[authcode]: {{< ref "sales-channels/authcode.md" >}}

--- a/content/sales-channels/testing.md
+++ b/content/sales-channels/testing.md
@@ -1,7 +1,7 @@
 ---
 title: "Testing the Sales Channel"
 draft: false
-weight: 3
+weight: 4
 ---
 
 The sales channel can be tested with the ID and channel secret shown below.
@@ -54,64 +54,3 @@ Below is an example of a form submit that sends payment order to Paytrail’s pa
     <input type="image" src="https://ssl.paytrail.com/logo/payhere_fin.jpg">
 </form>
 ```
-
-The last field `AUTHCODE` is calculated as follows:
-
-1. Combine all the fields in the same order they appear at the form.
-2. Insert pipe character (`|`) between the fields. If some field is not sent, insert a blank string (`''`) in its place. This will result in two or more pipe characters next to each other. The first field of the string has to be the channel secret. `AUTHCODE` will be created from this string with MD5 function. The value will be a 32 byte hexadecimal string.
-3. Replace lower case letters with upper case letters.
-
-{{% notice note %}}In this example character set UTF-8 is used. Paytrail supports character sets UTF-8 and ISO-8859-1. Calculation for AUTHCODE has to be done using same character set that is used when sending the form to Paytrail. Paytrail’s service will detect the used character set and use the same character set when calculating the AUTHCODE.{{% /notice %}}
-
-In the example above the values of fields are as described below.
-
-* **Channel secret:** `12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678`
-* **Channel ID**: `123`
-* **Order number:** `12345678`
-* **Currency:** `EUR`
-* **Return address (Successful payment):** <https://www.example.com/ok>
-* **Return address (Cancelled payment):** <https://www.example.com/cancel>
-* **Notify address:** <https://www.example.com/notify>
-* **Interface version:** `1`
-* **Culture code:** `fi_FI`
-* **Preselected method for the payment page bypass:** `1`
-* **Contact's telephone number:** `+01234567890`
-* **Contact's cellphone number:** `+35812345678`
-* **Contact's email address:** `example@example.com`
-* **Contact's first name:** _Jane_
-* **Contact's last name:** _Doe_
-* **Contact's company:** _Test Ltd_
-* **Contact's street address:** _Test Street 1_
-* **Contact's zip code:** _43210_
-* **Contact's city:** _Helsinki_
-* **Contact's country:** FI
-* **VAT included:** `1`
-* **Amount of items:** `2`
-* **Product #1**
-  * **Name:** _Example product 1_
-  * **Number:** `12345`
-  * **Amount:** `1`
-  * **Price:** `10.00`
-  * **Tax percent:** `22.00`
-  * **Merchant ID:** `13466`
-  * **Channel commission class ID:** `1`
-  * **Discount:** `0`
-  * **Type:** `1`
-* **Product #2**
-  * **Name:** _Example product 2_
-  * **Number:** `12345`
-  * **Amount:** `2`
-  * **Price:** `5.00`
-  * **Tax percent:** `22.00`
-  * **Merchant ID:** `13466`
-  * **Channel commission class ID:** `1`
-  * **Discount:** `20.00`
-  * **Type:** `1`
-
-The string used to calculate `AUTHCODE` is created by combining fields above.
-
-```plain
-12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678|123|12345678|EUR|https://www.example.com/ok|https://www.example.com/cancel|https://www.example.com/notify|1|fi_FI|||+35812345678||example@example.com|Jane|Doe|Test Ltd|Teststreet 1|43210|Helsinki|FI|1|2|Example product 1|12345|1|10.00|22.00|13466|1|0|1|Example product 2|12346|2|5.00|22.00|13466|1|20.00|1
-```
-
-MD5 hash value in upper case is `4FA11FF0D41C30B6F3A8AAEB814FD325`.

--- a/netlify.toml
+++ b/netlify.toml
@@ -43,6 +43,3 @@ from = "/*"
 to = "/404.html"
 status = 404
 force = false
-
-[[plugins]]
-package = "netlify-plugin-checklinks"


### PR DESCRIPTION
## What type of Pull Request is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

As agreed in the triage session, I moved the sales channel auth code calculation under an own page and fixed the `ITEM_UNIT_PRICE` description to require up to two decimals when brought to Paytrail service.

See the following pages for changes:

* [E2](https://deploy-preview-9--paytraildocs.netlify.app/payments/e2-interface/fields/)
* [Sales Channels](https://deploy-preview-9--paytraildocs.netlify.app/sales-channels/authcode/)

Additionally, committed some stylistic changes suggested by @hjalonen.

## Tests

- [x] Not needed (check the preview deployment)
- [ ] Unit tests added
- [ ] Integration tests added

## Related Tickets & Documents

Fixes #7 and #8.

## Code of Conduct

- [x] I have read and agreed to the [community code of conduct][coc]. The sole intention of this pull request is to improve the project codebase.

[coc]: https://github.com/paytrail/.github/blob/master/CODE_OF_CONDUCT.md
