### PR TITLE
Improve Merchant API documentation consistency and readability

### DIFF
--- a/content/refunds/_index.en.md
+++ b/content/refunds/_index.en.md
@@ -7,6 +7,6 @@ type: docs
 weight: 4
 ---
 
-See this section for creating, querying, and cancelling refunds via [Paytrail Merchant API][api].
+See this section for creating, querying, and cancelling refunds via **Paytrail Merchant API**. Accessing the API is described [**here**][api].
 
-[api]: {{< ref "merchant-api" >}}
+[api]: {{< ref "merchant-api/v1/accessing" >}}

--- a/content/refunds/create.md
+++ b/content/refunds/create.md
@@ -9,22 +9,40 @@ weight: 1
 Refunds are created using order numbers as identifiers. Merchants must use unique order numbers for Paytrail Merchant API to be able to link each refund to a single payment. The customer will be sent an email upon successful refund creation. Successful refund creation will return **HTTP status `202`** and refund location (link with a refund token). See section [General HTTP responses][responses].
 
 ```http
-POST /merchant/v1/payments/:orderNumber/refunds
+POST /merchant/v1/payments/:orderNumber/refunds HTTP/1.1
 ```
 
 ### Parameters
 
-- `email` (`string`, **optional**) \
-  When specified, the given email will be used for the refund. Required if the payment was made through the S1 interface if payment is not paid using card (email is not required for card payments).
-- `rows` (`array [1, 500]`, **required**)
-  - `amount` (`integer`, **required**) \
-    How much money to refund in cents (`>0–2000000`) with VAT included. The payment must have this much money left to refund, and for the right VAT percent, in case E1 or E2 interface with product rows was used.
-  - `vatPercent` (`integer`, **required/not allowed**) \
-    Which VAT percent to allocate the refund to, expressed in fractions of a hundred (0 – 10 000).
-  - `description` (`string`, **optional**) \
-    Description for the refund shown as product row name. This is visible to the customer as well.
-- `notifyUrl` (`string`, **optional**) \
-  A Valid webhook URL to call when a refund's status updates.
+#### `email`
+**Type:** `String`
+
+When specified, the given email will be used for the refund. Required if the payment was made through the S1 interface if payment is not paid using card (email is not required for card payments).
+
+#### `rows`
+**Type:** `Array[1, 500]`
+
+Required. List containing the refunded rows.
+
+#### `rows[].amount`
+**Type:** `Integer`
+
+Required. How much money to refund in cents (**1–2000000**) with VAT included. The payment must have this much money left to refund, and for the right VAT percent, in case E1 or E2 interface with product rows was used.
+
+#### `rows[].vatPercent`
+**Type:** `Integer`
+
+Required. Which VAT percent to allocate the refund to, expressed in fractions of a hundred (**0–10000**).
+
+#### `rows[].description`
+**Type:** `String`
+
+Description for the refund shown as product row name. This is visible to the customer as well.
+
+#### `notifyUrl`
+**Type:** `string`
+
+A valid webhook URL to call when a refund's status updates.
 
 [responses]: {{< relref "merchant-api/v1/accessing#responses" >}}
 

--- a/content/refunds/details.md
+++ b/content/refunds/details.md
@@ -11,12 +11,15 @@ weight: 2
 Returns refund details.
 
 ```http
-GET /merchant/v1/refunds/:id
+GET /merchant/v1/refunds/:id HTTP/1.1
 ```
 
 ### Parameters
 
-- `id` (`string`, **required**) Refund token whose details are requested.
+#### `id`
+**Type:** `String`
+
+Required. Refund token whose details are requested.
 
 ### Request
 
@@ -39,8 +42,6 @@ Content-Type: application/json
 **Body:**
 
 ```json
-HTTP/1.1 200 OK
-Content-Type: application/json
 {
     "id": "DA2OTA4NWVmYTRiMDUyMWI4OGNkNjkxNzBh",
     "createdAt": "2015-01-02T14:00:02+00:00",
@@ -59,4 +60,6 @@ Content-Type: application/json
 
 ### Resource Specific Error Messages
 
-- `invalid-refund-token` (**Code:** `404`) Invalid refund token. Check refund token. You can check the value from Merchant's Panel.
+#### `invalid-refund-token (404)`
+
+Invalid refund token. Check refund token. You can check the value from Merchant's Panel.

--- a/content/refunds/notify.md
+++ b/content/refunds/notify.md
@@ -16,21 +16,39 @@ If an update is not acknowledged by the receiving end, the update to that refund
 
 ### Parameters
 
-- `refundToken` – Refund token.
-- `oldStatus` – Refund's previous status.
-- `newStatus` – Refund's new status
-- `signature` – Signature to ensure the update comes from Paytrail.
-  
-Signature is calculated with the following formula: 
+#### `refundToken`
+**Type:** `String`
 
-```rb
-sha256(:refundToken + '|' + :oldStatus + '|' + :newStatus + '|' + :merchantSecret)
+Refund token.
+
+#### `oldStatus`
+**Type:** `String`
+
+Refund's previous status.
+
+#### `newStatus`
+**Type:** `String`
+
+Refund's new status.
+
+#### `signature`
+**Type:** `String`
+
+Signature to ensure the update comes from Paytrail. Signature is calculated with the following formula.
+
+```js
+sha256(refundToken + '|' + oldStatus + '|' + newStatus + '|' + merchantSecret)
 ```
 
 ### Refund Statuses
 
-- `created` – Refund was created. Never used as `newStatus`, since notify is not sent when a refund is created.
-- `completed` – Refund paid to customer. For bank or _Collector_ refund, amount is deducted from merchant's settlement.
-- `cancelled` – Refund cancelled or failed.
+#### `created`
+Refund was created. Never used as `newStatus`, since notify is not sent when a refund is created.
+
+#### `completed`
+Refund paid to customer. For bank or _Collector_ refund, amount is deducted from merchant's settlement.
+
+#### `cancelled`
+Refund cancelled or failed.
 
 {{% notice note %}}New statuses may be introduced in the future. Implementations should be able to discard any other statuses received.{{% /notice %}}

--- a/content/settlements/_index.en.md
+++ b/content/settlements/_index.en.md
@@ -7,10 +7,10 @@ type: docs
 weight: 5
 ---
 
-See this section for listing settlements and querying their details via [Paytrail Merchant API][api].
+See this section for listing settlements and querying their details via **Paytrail Merchant API**. Accessing the API is described [**here**][api].
 
 {{< notice warning >}}Merchant API settlements feature is not available for demo merchant (13466).{{< /notice >}}
 
 {{< notice note >}}An agreement modification is required to enable settlements via Merchant API.{{< /notice >}}
 
-[api]: {{< ref "merchant-api" >}}
+[api]: {{< ref "merchant-api/v1/accessing" >}}

--- a/content/settlements/details.md
+++ b/content/settlements/details.md
@@ -9,7 +9,7 @@ weight: 2
 Returns settlement details.
 
 ```http
-GET /merchant/v1/settlements/:id
+GET /merchant/v1/settlements/:id HTTP/1.1
 ```
 
 #### Request

--- a/content/settlements/list.md
+++ b/content/settlements/list.md
@@ -9,7 +9,7 @@ weight: 1
 Returns settlements created between selected time span.
 
 ```http
-GET /merchant/v1/settlements?fromDate=from&toDate=to
+GET /merchant/v1/settlements?fromDate=from&toDate=to HTTP/1.1
 ```
 
 ### Parameters


### PR DESCRIPTION
## What type of Pull Request is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The parameter lists in Merchant API refunds and settlements documentation have been aligned to use header tags instead of lists, and now they look more consistent. I also fixed our REST snippets to denote the `HTTP/1.1` being used since otherwise those snippets were highlighted with syntax error (dark red background).

Locating how to access the Merchant API is now easier since we link directly to that page from refunds and settlements.

## Tests

- [ ] Not needed
- [ ] Unit tests added
- [ ] Integration tests added
- [x] Verified UI changes

## Related Tickets & Documents

- Fixes #17
- Fixes #30

## Code of Conduct

- [x] I have read and agreed to the [community code of conduct][coc]. The sole intention of this pull request is to improve the project codebase.

[coc]: https://github.com/paytrail/.github/blob/master/CODE_OF_CONDUCT.md
