### PR TITLE
Fix E2 field validation details and link to E2 when mentioning form interface

### DIFF
--- a/content/credentials/_index.en.md
+++ b/content/credentials/_index.en.md
@@ -9,7 +9,7 @@ weight: 6
 
 **Paytrail Payment Service** is testable using merchant ID `13466` and merchant secret `6pKF4jkv97zmqBJ3ZL8gUw5DfT2NMQ`. These test credentials work with [form interface][form], [REST interface][rest] and payment method selection page embedding.
 
-[form]: {{< ref "form-interface" >}}
+[form]: {{< ref "payments" >}}
 [rest]: {{< ref "rest-interface" >}}
 
 **Shopify** gateway is testable using merchant ID `13466` and Shopify token `d3d86c09e781a00dda469e420166623f67a618e6`.

--- a/content/legacy/embedding/_index.en.md
+++ b/content/legacy/embedding/_index.en.md
@@ -20,6 +20,6 @@ JavaScript interface offers two methods; one is used for the chosen payment inte
 
 The widget version **1.0** can be downloaded [**here**][widget] (_18 KB, minified_).
 
-[form]: {{< ref "form-interface" >}}
+[form]: {{< ref "payments" >}}
 [rest]: {{< ref "rest-interface" >}}
 [widget]: https://payment.paytrail.com/js/payment-widget-v1.0.min.js

--- a/content/payments/e2-interface/validation.md
+++ b/content/payments/e2-interface/validation.md
@@ -24,7 +24,7 @@ Valid URL including http(s). URLs that do not include any dots (e.g. <http://loc
 `0-9, a-z, A-Z and ()[]{}*+-_,`. As regular expression `/^[0-9a-zA-Z()[]{}*+-_,.]{1,64}$/`. (64)
 
 #### `AMOUNT`
-Float between `0.65–499999` (10)
+Float between `0.65–499999.99` (10)
 
 #### `PARAMS_IN`
 `0-9, A-Z, [],_`. (4096)
@@ -81,7 +81,7 @@ Unicode alphabets and `()[]{}*+-_,:&!?@#$£=*;~/\"'`. See regular expression fro
 `0-9`, `+-`. (64)
 
 #### `PAYER_PERSON_ADDR_STREET`
-Unicode alphabets. (128)
+Unicode alphabets. As regular expression `/^[\pL-0-9- \"\',. ]*$/u`. (128)
 
 #### `PAYER_PERSON_ADDR_POSTAL_CODE`
 `0-9`, `a-z`, `A-Z`. (16)


### PR DESCRIPTION
## What type of Pull Request is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- Maximum value of the `AMOUNT` field in E2 is specified with two decimals.
- `PAYER_PERSON_ADDR_STREET` validation contains a regular expression we use server-side.
- Links to E1 interface replaced with respective links to E2.

## Tests

- [ ] Not needed
- [ ] Unit tests added
- [ ] Integration tests added
- [x] Visual verification done.

## Related Tickets & Documents

- Fixes #20
- Fixes #23

## Code of Conduct

- [x] I have read and agreed to the [community code of conduct][coc]. The sole intention of this pull request is to improve the project codebase.

[coc]: https://github.com/paytrail/.github/blob/master/CODE_OF_CONDUCT.md
