### PR TITLE
List deprecated payment method IDs separately

### DIFF
--- a/content/best-practices/requirements.md
+++ b/content/best-practices/requirements.md
@@ -24,3 +24,8 @@ A number of payment methods have strict requirements when posting a new payment 
 
 * Customer details should be sent with the `PAYER_PERSON_*` fields.
 * Klarna is only available as an interface which requires own agreement with Klarna, and it's hidden until the credentials are saved in Merchant’s Panel.
+
+### Paypal
+
+* Only available as an interface.
+* Requires own agreement with PayPal and is hidden until credentials are saved in Merchant's Panel.

--- a/content/payment-methods/values.md
+++ b/content/payment-methods/values.md
@@ -3,7 +3,11 @@ title: "Payment Method IDs and Names"
 draft: false
 ---
 
-This list defines the ID numbers for different payment methods supported by Paytrail.
+### Active
+
+This list defines the ID numbers for active payment methods supported by Paytrail.
+
+Certain payment methods have requirements or limitations regarding their use. You should check the requirements from [**here**][requirements].
 
 * **1** _Nordea_
 * **2** _Osuuspankki_
@@ -11,26 +15,10 @@ This list defines the ID numbers for different payment methods supported by Payt
 * **5** _Ålandsbanken_
 * **6** _Handelsbanken_
 * **9** _PayPal_
-  
-  Only available as an interface. Requires own agreement with PayPal and is hidden until credentials are saved in Merchant's Panel.
-
 * **10** _S-Pankki_
 * **11** _Klarna Invoice_
-  
-  Field `PAYER_PERSON_PHONE` and payer details should be defined (name, address, zip, city, and country). Only available as an interface. Requires own agreement with Klarna, and is hidden until credentials are saved in Merchant's Panel.
-
 * **12** _Klarna Installment_
-  
-  Field `PAYER_PERSON_PHONE` and payer details should be defined (name, address, zip, city, and country). Only available as an interface. Requires own agreement with Klarna and is hidden until credentials are saved in Merchant's Panel.
-
 * **18** _Jousto_
-  
-  Amount must be between 20 and 5000 €.
-
-* **30** _Visa_
-* **31** _MasterCard_
-* **34** _Diners Club_
-* **35** _JCB_
 * **50** _Aktia_
 * **51** _POP Pankki_
 * **52** _Säästöpankki_
@@ -40,7 +28,15 @@ This list defines the ID numbers for different payment methods supported by Payt
 * **56** _American Express (Nets)_
 * **58** _MobilePay_
 * **60** _Collector Bank_
-  
-  Field `VAT_IS_INCLUDED` should be `1`. Field `ITEM_QUANTITY[N]` should be an integer. Maximum amount is 5000 €. Product details should be defined. Payer details should be defined (name, address, zip, city, and country)
-
 * **61** _Oma Säästöpankki_
+
+### Deprecated
+
+Following payment methods have been deprecated by Paytrail and should not be used anymore. Check from the Merchant's Panel what active payment methods you can use.
+
+* **30** _Visa_
+* **31** _MasterCard_
+* **34** _Diners Club_
+* **35** _JCB_
+
+[requirements]: {{< ref "best-practices/requirements" >}}


### PR DESCRIPTION
## What type of Pull Request is this?

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

As suggested by support, this PR changes the way we list payment methods. Active and deprecated methods are grouped under their own headers. I feel deprecated methods should be listed for visibility, but feel free to challenge me.

Also, moved the PayPal limitations under _Best Practices_ to make the list more concise and readable. Klarna, Jousto, and Collector limitations were already moved in #21.

## Tests

- [ ] Not needed
- [ ] Unit tests added
- [ ] Integration tests added
- [x] Visual verification done

## Related Tickets & Documents

* Fixes #28

## Code of Conduct

- [x] I have read and agreed to the [community code of conduct][coc]. The sole intention of this pull request is to improve the project codebase.

[coc]: https://github.com/paytrail/.github/blob/master/CODE_OF_CONDUCT.md
