### PR TITLE
Redirect old routes to homepage

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -39,6 +39,14 @@ HUGO_VERSION = "0.70.0"
 # For context-specific rules, use _headers or _redirects files, which are
 # PER-DEPLOY.
 [[redirects]]
+# Redirect default structure from old site
+from = "/en/*"
+to = "/"
+status = 301
+force = true
+
+[[redirects]]
+# 404 page
 from = "/*"
 to = "/404.html"
 status = 404


### PR DESCRIPTION
## What type of Pull Request is this?

Check all the applicable.

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This rule forces all the `/en/*` routes to the homepage. When we switch the domains, it should not cause any 404 pages from our old shared links.

The `force = true` directive prevents us from inserting a content directory under `en/` and forgetting the redirect rule. Should we need to translate the docs to another language, we can and should remove this rule.
 
## Tests

- [ ] Not needed
- [ ] Unit tests added
- [ ] Integration tests added
- [x] Visual verification done

**Example:**

Going to URL <https://deploy-preview-50--paytraildocs.netlify.app/en/ch04s08.html> should redirect to the homepage. Do test any edge cases imaginable.

## Related Tickets & Documents

Fixes #37

## Code of Conduct

- [x] I have read and agreed to the [community code of conduct][coc]. The sole intention of this pull request is to improve the project codebase.

[coc]: https://github.com/paytrail/.github/blob/master/CODE_OF_CONDUCT.md
