### PR TITLE
Fix sitemap URLs to be absolute instead of relative

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://docs.paytrail.com/"
 languageCode = "en-us"
 title = "Paytrail Integration Guide"
 theme = "dot"


### PR DESCRIPTION
## What type of Pull Request is this?

Check all the applicable.

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

These changes should fix the issues with the `sitemap.xml` file where Google and others
can't parse relative URLs.

Setting the `baseURL` in configuration to the production URL seems to fix this, and the sitemap now contains absolute URLs. Test this by appending `/sitemap.xml` at the end of the preview deployment URL.

## Tests

- [ ] Not needed
- [ ] Unit tests added
- [ ] Integration tests added
- [x] Visual verification done

Check that the XML tree in <https://deploy-preview-61--paytraildocs.netlify.app/sitemap.xml> contains absolute links under each `<loc>` node.

## Code of Conduct

- [x] I have read and agreed to the [community code of conduct][coc]. The sole intention of this pull request is to improve the project codebase.

[coc]: https://github.com/paytrail/.github/blob/master/CODE_OF_CONDUCT.md
