### PR TITLE
Adjust the old minimum payment sum accepted by Paytrail to the new lower one

### DIFF
--- a/content/credentials/_index.en.md
+++ b/content/credentials/_index.en.md
@@ -82,4 +82,4 @@ The amount ranges `0.01` to `0.99` and `1.01` to `4.99` will always make the cre
 - **Password:** Bank's web site will provide these for you.
 - **Security code:** Bank's web site will provide these for you.
 
-Remember that Paytrail also sets a minimum limit for payment amount that is **0,65 €**.
+Remember that Paytrail also sets a minimum limit for payment amount that is **0.01 €**.

--- a/content/legacy/e1-interface/fields.md
+++ b/content/legacy/e1-interface/fields.md
@@ -183,7 +183,7 @@ Number of products. Usually the value is `1` (_required_). If using the Collecto
 #### `ITEM_PRICE[N] (*)`
 **Type**: `Float[10]`
 
-The price for a single product. If `INCLUDE_VAT = 0`, this is price not including VAT. If `INCLUDE_VAT = 1`, this price includes VAT. Price may be negative value if a discount is given. Payment total must be positive. Total sum of the product prices must be at least 0.65 €.
+The price for a single product. If `INCLUDE_VAT = 0`, this is price not including VAT. If `INCLUDE_VAT = 1`, this price includes VAT. Price may be negative value if a discount is given. Payment total must be positive. Total sum of the product prices must be at least 0.01 €.
 
 #### `ITEM_TAX[N] (*)`
 **Type**: `Float[10]`

--- a/content/legacy/rest-interface/payment-creation.md
+++ b/content/legacy/rest-interface/payment-creation.md
@@ -29,7 +29,7 @@ Payment currency. Value must be EUR for Finnish banks, otherwise the payment wil
 Localisation defines default language for the payment method selection page and presentation format for the sums. Available localisations are `fi_FI` , `sv_SE` and `en_US`. The default localisation is `fi_FI`.
 
 - `price` (decimal number[10], optional) \
-  Payment total. Send either exact payment data (`orderDetails`) or the payment total to the service. If you send only the payment total price, (_Klarna_ and _Collector_) invoice and instalment payment methods are not available and order details cannot be shown in the Merchant's Panel. We recommend using `orderDetails` record whenever it is possible. The value of price must be greater or equal than `0.65`.
+  Payment total. Send either exact payment data (`orderDetails`) or the payment total to the service. If you send only the payment total price, (_Klarna_ and _Collector_) invoice and instalment payment methods are not available and order details cannot be shown in the Merchant's Panel. We recommend using `orderDetails` record whenever it is possible. The value of price must be greater or equal than `0.01`.
 
 - `urlSet` (required)
 
@@ -79,7 +79,7 @@ Either `orderDetails` or payment sum price has to be specified. `orderDetails` r
       - `amount` (decimal number[10], required) \
         If an order has several same products, you can enter the number of products here instead of having separate rows for each. Usually this field contains the value `1`. If Collector payment method is used, the value should be an integer. If a decimal such as `0.5` is used, Collector payment method is hidden from the payment method selection page.
       - `price` (decimal number[10], required) \
-        Price for one product. If the field payment.orderDetails.includeVat = 0, the price excludes VAT. If the value is 1, the price includes VAT. The price can also be negative if you want to add discounts to the service. However, the total amount of the product rows must always be at least 0.65.
+        Price for one product. If the field payment.orderDetails.includeVat = 0, the price excludes VAT. If the value is 1, the price includes VAT. The price can also be negative if you want to add discounts to the service. However, the total amount of the product rows must always be at least 0.01.
       - `vat` (decimal number[10], required) \
         Tax percentage for a product.
       - `discount` (decimal number[10], optional) \

--- a/content/legacy/s1-interface/fields.md
+++ b/content/legacy/s1-interface/fields.md
@@ -24,7 +24,7 @@ Order number is used to identify one transaction from another in the webshop sof
 
 Price is given in euros and cents. Price is given without currency type and decimals are separated with a dot. Price must contain two decimals.
 
-**Example:** `15.50`. Minimum price accepted by the service is **0.65 €**.
+**Example:** `15.50`. Minimum price accepted by the service is **0.01 €**.
 
 #### `REFERENCE_NUMBER`
 **Type**: `Number[50]`

--- a/content/payments/e2-interface/fields.md
+++ b/content/payments/e2-interface/fields.md
@@ -34,7 +34,7 @@ URL where customer is redirected after failed or cancelled payment. `PARAMS_OUT`
 Used to identify one transaction.
 
 #### `AMOUNT (*)`
-Price is given in euros and cents without currency. Decimals are separated with a dot. Must contain **two decimals**. Interface accepts values between **0.65–499 999.99 €**. Some payment methods have limitations for this value which you can check [**here**][requirements].
+Price is given in euros and cents without currency. Decimals are separated with a dot. Must contain **two decimals**. Interface accepts values between **0.01 – 499 999.99 €**. Some payment methods have limitations for this value which you can check [**here**][requirements].
 
 #### `PARAMS_IN (*)`
 Comma separated list of fields used in `AUTHCODE` calculation. Only values listed in this field are shown in payment data.
@@ -133,7 +133,7 @@ Order rows can be brought to Paytrail service using the following repetitive fie
 
 Required fields when product rows are included in the data are `ITEM_TITLE`, `ITEM_UNIT_PRICE`, and `ITEM_VAT_PERCENT`. These are marked with an asterisk `(*)`.
 
-Total sum of the product prices must be between **0.65 – 499 999.99 €**. Some payment methods have limitations for this value which you can check [**here**][requirements].
+Total sum of the product prices must be between **0.01 – 499 999.99 €**. Some payment methods have limitations for this value which you can check [**here**][requirements].
 
 #### `ITEM_TITLE[N] (*)`
 Free field for the product name.

--- a/content/payments/e2-interface/validation.md
+++ b/content/payments/e2-interface/validation.md
@@ -24,7 +24,7 @@ Valid URL including http(s). URLs that do not include any dots (e.g. <http://loc
 `0-9, a-z, A-Z and ()[]{}*+-_,`. As regular expression `/^[0-9a-zA-Z()[]{}*+-_,.]{1,64}$/`. (64)
 
 #### `AMOUNT`
-Float between `0.65–499999.99` (10)
+Float between `0.01 – 499999.99` (10)
 
 #### `PARAMS_IN`
 `0-9, A-Z, [],_`. (4096)


### PR DESCRIPTION
## What type of Pull Request is this?

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Changes the minimum sum accepted by Paytrail's service from 0.65 to 0.01 €. Changes have been done to test credentials, legacy interfaces, and the E2 interface.

Pushed this in 3 separate commits. When this is ready to merge, those commits may be squashed as one.

> **The new minimum sum is not yet in production. Don't merge this without approval from Paytrail!**

## Tests

- [ ] Not needed
- [ ] Unit tests added
- [ ] Integration tests added
- [x] Visual verification done

## Code of Conduct

- [x] I have read and agreed to the [community code of conduct][coc]. The sole intention of this pull request is to improve the project codebase.

[coc]: https://github.com/paytrail/.github/blob/master/CODE_OF_CONDUCT.md
