### PR TITLE
Revert REST interface documentation to beta phase

### DIFF
--- a/content/legacy/rest-interface/_index.en.md
+++ b/content/legacy/rest-interface/_index.en.md
@@ -1,14 +1,16 @@
 ---
-title: "Rest Interface"
+title: "Rest Interface (Beta)"
 draft: false
 weight: 5
 ---
 
 ### Description
 
-Paytrail payment REST interface can be used to create a payment with a server-to-server request and thus limits usage less than the form interface. With the REST interface, the payment is created in advance by sending payment data as an _XML_ or _JSON_ message over _HTTPS_. Service returns the response message in the corresponding format.
+{{< notice warning >}}
+REST interface has been deprecated and doesn't support advanced features like payment page bypass. We recommend using E2 form interface instead.
+{{< /notice >}}
 
-{{% notice warning %}}REST interface does not support payment page bypass.{{% /notice %}}
+Paytrail payment REST interface can be used to create a payment with a server-to-server request and thus limits usage less than the form interface. With the REST interface, the payment is created in advance by sending payment data as an _XML_ or _JSON_ message over _HTTPS_. Service returns the response message in the corresponding format.
 
 We offer a PHP package for creating payments with the REST interface easily. You can import the package to your project with **Composer** like so:
 
@@ -21,6 +23,10 @@ The package requires **PHP 7.2** or newer. The detailed documentation is availab
 If you encounter any problems using the package don't hesitate reporting them to us in GitHub. You can also participate in the package development by submitting us pull requests.
 
 ### Usage
+
+{{< notice note >}}
+Even though REST interface is marked as beta, it is considered a stable product. Paytrail will not implement backwards incompatible or otherwise breaking changes to it without prior notice.
+{{< /notice >}}
 
 When using the form interface the payment data is sent from a customer's browser to Paytrail service, but when using the REST interface customer's server sends the payment data to Paytrail service in _XML_ or _JSON_ format. The response message is returned in the same format.
 

--- a/content/legacy/rest-interface/error-codes.md
+++ b/content/legacy/rest-interface/error-codes.md
@@ -1,6 +1,7 @@
 ---
 title: "Error Codes"
 draft: false
+weight: 3
 ---
 
 The following fields are the error codes returned during an unsuccessful payment creation.

--- a/content/legacy/rest-interface/error-handling.md
+++ b/content/legacy/rest-interface/error-handling.md
@@ -1,6 +1,7 @@
 ---
 title: "Error Handling"
 draft: false
+weight: 2
 ---
 
 If the sent request is incorrect or there is an error in the interface usage, the interface returns an error message. The error message is in _XML_ or _JSON_ format depending on the request data type (`Content-Type` header). If the data type is incorrect or it was not read, the error message is returned in XML format. Return message for an incorrect request is returned with HTTP error code 400.

--- a/content/legacy/rest-interface/payment-creation.md
+++ b/content/legacy/rest-interface/payment-creation.md
@@ -1,6 +1,7 @@
 ---
 title: "Payment Creation"
 draft: false
+weight: 1
 ---
 
 Paytrail payment service REST interface allows for creating a payment in advance with a simple HTTP POST request, which sends the payment data as an _XML_ or _JSON_ message. The request returns an order number, payment ID (_token_) and URL address for making a payment. In a typical case, a webshop creates a payment with the REST interface at the end of an order process, and redirects the customer to the returned URL.


### PR DESCRIPTION
## What type of Pull Request is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Adds mention of the REST interface being still in beta phase back to the documentation.

Also improves ordering of child pages so that payment creation comes before error handling as suggested in #57.

## Tests

- [ ] Not needed
- [ ] Unit tests added
- [ ] Integration tests added
- [x] Visual verification done

## Related Tickets & Documents

Fixes #72

## Code of Conduct

- [x] I have read and agreed to the [community code of conduct][coc]. The sole intention of this pull request is to improve the project codebase.

[coc]: https://github.com/paytrail/.github/blob/master/CODE_OF_CONDUCT.md
