### PR TITLE
fix: add mention about negative product amount and mandatority of refund vat percent

### DIFF
--- a/content/payments/e2-interface/fields.md
+++ b/content/payments/e2-interface/fields.md
@@ -147,6 +147,8 @@ Optional quantity of products. Default is `1`. If a decimal number such as `0.5`
 #### `ITEM_UNIT_PRICE[N] (*)`
 The price for a single product with **up to two decimals**.
 
+Value can be negative for individual products, but whole order total amount must be positive value.
+
 If `VAT_IS_INCLUDED = 0`, this is price excluding VAT. Price may be negative value if discount is given.
 
 #### `ITEM_VAT_PERCENT[N] (*)`

--- a/content/payments/e2-interface/fields.md
+++ b/content/payments/e2-interface/fields.md
@@ -132,6 +132,7 @@ Payer's company.
 Order rows can be brought to Paytrail service using the following repetitive fields. First order item row is brought with index 0 (for example name of the first product in field `ITEM_TITLE[0]`). Number of the order rows can not exceed **500**.
 
 Required fields when product rows are included in the data are `ITEM_TITLE`, `ITEM_UNIT_PRICE`, and `ITEM_VAT_PERCENT`. These are marked with an asterisk `(*)`.
+All items should be consistent. If one item has `ITEM_ID`, every item should have it.
 
 Total sum of the product prices must be between **0.65 – 499 999.99 €**. Some payment methods have limitations for this value which you can check [**here**][requirements].
 

--- a/content/payments/e2-interface/validation.md
+++ b/content/payments/e2-interface/validation.md
@@ -105,7 +105,7 @@ Unicode alphabets and `()[]{}*+-_,:&!?@#$£=*;~/\"'`. See regular expression fro
 Floating point number. (10)
 
 #### `ITEM_UNIT_PRICE`
-Floating point number. between `0–499 999.99`. (10)
+Floating point number. between `–499 999.99 – 499 999.99`. (10)
 
 #### `ITEM_VAT_PERCENT`
 Floating point number. between `0-100`. (10)

--- a/content/refunds/create.md
+++ b/content/refunds/create.md
@@ -43,7 +43,9 @@ Required. How much money to refund in cents (**1–49999999**) with VAT included
 #### `rows[].vatPercent`
 **Type:** `Integer`
 
-Required. Which VAT percent to allocate the refund to, expressed in fractions of a hundred (**0–10000**).
+Required/Not allowed. Which VAT percent to allocate the refund to, expressed in fractions of a hundred (**0–10000**).
+
+Required if product information was used in original order. Not allowed if order was placed with amount instead of product information.
 
 #### `rows[].description`
 **Type:** `String`


### PR DESCRIPTION
…und vat percent

## What type of Pull Request is this?

Check all the applicable.

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description
Define negative product amount and correct validation for product amount.
Add not allowed status to refund vat percent if product information was not used.

## Tests

- [ ] Not needed
- [ ] Unit tests added
- [ ] Integration tests added
- [X] Visual verification done

## Related Tickets & Documents

Fixes #70 and #79 

## Code of Conduct

- [X] I have read and agreed to the [community code of conduct][coc]. The sole intention of this pull request is to improve the project codebase.

[coc]: https://github.com/paytrail/.github/blob/master/CODE_OF_CONDUCT.md
